### PR TITLE
Adds openapi spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ public/uploads/*
 !public/uploads/.gitkeep
 .tsbuildinfo
 .eslintcache
+public/openapi.json
 
 ############################
 # Node.js

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "deploy": "strapi deploy",
     "dev": "strapi develop",
     "develop": "strapi develop",
+    "openapi": "strapi openapi generate --output ./public/openapi.json",
     "seed:example": "node ./scripts/seed.js",
     "start": "strapi start",
     "strapi": "strapi",


### PR DESCRIPTION
Added a script that generates an openapi.json file in the public folder. Having it in the public folder allows us to serve it locally at localhost:1337/openapi.json so our front-end codegen can read and consume the file.

I gitignored it because we don't need/want the file in prod.

---

OpenApi (formerly known as Swagger) is the most well-known standardized format for a "REST" API. The spec also describes a JSON format of it which has a lot of tooling around it. Most pertinent here, is that we can use that json file to generate typescript types for all of our schemas and endpoints in the front-end. Ensuring type safety